### PR TITLE
Issue 111 and 27 global hotkeys and nw upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ components/**/*
 www/js/Encryptr-tests.js
 www/js/Encryptr-templates.js
 desktopbuilds/*
+cache

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,15 +146,23 @@ module.exports = function(grunt) {
       }
     },
     nodewebkit: {
+      // This has a mishmash of old and new options just for compatibility
       options: {
+        version: '0.11.5',
         build_dir: './desktopbuilds',
         mac: true,
         mac_icns: './resources/icon-encryptr.icns',
+        macIcns: './resources/icon-encryptr.icns',
         mac_bundle_id: 'org.devgeeks.encryptr',
+        macPlist: {
+          CFBundleIdentifier: 'org.devgeeks.encryptr'
+        },
+        winIco: './resources/icon-encryptr.ico',
         win: true,
         linux32: true,
         linux64: true,
-        credits: './www/credits.html'
+        credits: './www/credits.html',
+        macCredits: './www/credits.html'
       },
       src: ['./www/**/*'] // Your node-webkit app
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -244,6 +244,7 @@ module.exports = function(grunt) {
     grunt.task.run('shell:mocha' + (which || 'spec'));
   });
   grunt.registerTask('desktop', 'Build for desktop', function(which) {
+    grunt.task.run('jshint', 'dot', 'copy', 'concat', 'min', 'shell:mochadot');
     if (which === 'release') {
       grunt.task.run('nodewebkit:release');
     } else {
@@ -253,7 +254,11 @@ module.exports = function(grunt) {
   grunt.registerTask('min', ['uglify']); // polyfil for uglify
   grunt.registerTask('debug','Create a debug build', function(platform) {
     grunt.task.run('jshint', 'dot', 'copy', 'concat', 'min', 'shell:mochadot');
-    grunt.task.run('shell:debug_' + platform);
+    if (platform === 'desktop') {
+      grunt.task.run('nodewebkit:debug');
+    } else {
+      grunt.task.run('shell:debug_' + platform);
+    }
   });
 
   // Default task

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,25 +147,48 @@ module.exports = function(grunt) {
     },
     nodewebkit: {
       // This has a mishmash of old and new options just for compatibility
-      options: {
-        version: '0.11.5',
-        build_dir: './desktopbuilds',
-        mac: true,
-        mac_icns: './resources/icon-encryptr.icns',
-        macIcns: './resources/icon-encryptr.icns',
-        mac_bundle_id: 'org.devgeeks.encryptr',
-        macPlist: {
-          CFBundleIdentifier: 'org.devgeeks.encryptr'
+      release: {
+        options: {
+          version: '0.11.5',
+          build_dir: './desktopbuilds',
+          mac: true,
+          mac_icns: './resources/icon-encryptr.icns',
+          macIcns: './resources/icon-encryptr.icns',
+          mac_bundle_id: 'org.devgeeks.encryptr',
+          macPlist: {
+            CFBundleIdentifier: 'org.devgeeks.encryptr'
+          },
+          cacheDir: './desktopbuilds/cache',
+          winIco: './resources/icon-encryptr.ico',
+          win: true,
+          linux32: true,
+          linux64: true,
+          credits: './www/credits.html',
+          macCredits: './www/credits.html'
         },
-        cacheDir: './desktopbuilds/cache',
-        winIco: './resources/icon-encryptr.ico',
-        win: true,
-        linux32: true,
-        linux64: true,
-        credits: './www/credits.html',
-        macCredits: './www/credits.html'
+        src: ['./www/**/*'] // Your node-webkit app
       },
-      src: ['./www/**/*'] // Your node-webkit app
+      // Don't try and force wine icon replacement on debug builds
+      debug: {
+        options: {
+          version: '0.11.5',
+          build_dir: './desktopbuilds',
+          mac: true,
+          mac_icns: './resources/icon-encryptr.icns',
+          macIcns: './resources/icon-encryptr.icns',
+          mac_bundle_id: 'org.devgeeks.encryptr',
+          macPlist: {
+            CFBundleIdentifier: 'org.devgeeks.encryptr'
+          },
+          cacheDir: './desktopbuilds/cache',
+          win: true,
+          linux32: true,
+          linux64: true,
+          credits: './www/credits.html',
+          macCredits: './www/credits.html'
+        },
+        src: ['./www/**/*'] // Your node-webkit app
+      }
     },
     jshint: {
       files: ['Gruntfile.js', 'src/*.js', 'src/**/*.js'],
@@ -219,6 +242,13 @@ module.exports = function(grunt) {
   grunt.registerTask('test', 'Do mocha test, default spec', function(which) {
     grunt.task.run('jshint', 'dot', 'copy', 'concat', 'min');
     grunt.task.run('shell:mocha' + (which || 'spec'));
+  });
+  grunt.registerTask('desktop', 'Build for desktop', function(which) {
+    if (which === 'release') {
+      grunt.task.run('nodewebkit:release');
+    } else {
+      grunt.task.run('nodewebkit:debug');
+    }
   });
   grunt.registerTask('min', ['uglify']); // polyfil for uglify
   grunt.registerTask('debug','Create a debug build', function(platform) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,6 +157,7 @@ module.exports = function(grunt) {
         macPlist: {
           CFBundleIdentifier: 'org.devgeeks.encryptr'
         },
+        cacheDir: './desktopbuilds/cache',
         winIco: './resources/icon-encryptr.ico',
         win: true,
         linux32: true,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "colors": "^0.6.2",
     "wd": "^0.3.1",
     "wd-query": "^0.2.0",
-    "grunt-node-webkit-builder": "https://github.com/devgeeks/grunt-node-webkit-builder/archive/master.tar.gz"
+    "grunt-node-webkit-builder": "^1.0.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -136,10 +136,11 @@ var Encryptr = (function (window, console, undefined) {
       Encryptr.prototype.copyToClipboard = window.community.clipboard.setText;
     // How to *actually* detect node-webkit ?
     } else if ($.os.nodeWebkit && window.require ) {
-      var gui = window.require('nw.gui');
+      /* jshint node: true */
+      var gui = require('nw.gui');
       var win = gui.Window.get();
-      var nativeMenuBar = new gui.Menu({ type: "menubar" });
-      if (nativeMenuBar.createMacBuiltin) {
+      if (process.platform === "darwin") {
+        var nativeMenuBar = new gui.Menu({ type: "menubar" });
         nativeMenuBar.createMacBuiltin("Encryptr");
         win.menu = nativeMenuBar;
       }
@@ -162,6 +163,7 @@ var Encryptr = (function (window, console, undefined) {
       Encryptr.prototype.copyToClipboard = function(text) {
         window.clipboard.set(text, 'text');
       };
+      /* jshint node: false */
     } else {
       // Fallback to empty browser polyfill
       Encryptr.prototype.copyToClipboard = function() {};

--- a/src/app.js
+++ b/src/app.js
@@ -137,6 +137,27 @@ var Encryptr = (function (window, console, undefined) {
     // How to *actually* detect node-webkit ?
     } else if ($.os.nodeWebkit && window.require ) {
       var gui = window.require('nw.gui');
+      var win = gui.Window.get();
+      var nativeMenuBar = new gui.Menu({ type: "menubar" });
+      if (nativeMenuBar.createMacBuiltin) {
+        nativeMenuBar.createMacBuiltin("Encryptr");
+        win.menu = nativeMenuBar;
+      }
+      var option = {
+        key : "Ctrl+Alt+Shift+E",
+        active : function() {
+          win.focus();
+        },
+        failed : function(msg) {
+          // :(, fail to register the |key| or couldn't parse the |key|.
+          console.log(msg);
+        }
+      };
+      // Create a shortcut with |option|.
+      var shortcut = new gui.Shortcut(option);
+      // Register global desktop shortcut, which can work without focus.
+      gui.App.registerGlobalHotKey(shortcut);
+
       window.clipboard = gui.Clipboard.get();
       Encryptr.prototype.copyToClipboard = function(text) {
         window.clipboard.set(text, 'text');

--- a/src/views/EntryView.js
+++ b/src/views/EntryView.js
@@ -9,6 +9,7 @@
   var EntryView = Backbone.View.extend({
     events: {
       "longTap .copyable": "copyable_longTapHandler",
+      "dblclick .copyable": "copyable_doubleTapHandler",
       "click .eye": "eye_clickHandler"
     },
     initialize: function() {
@@ -16,6 +17,7 @@
           "render",
           "editButton_clickHandler",
           "deleteButton_clickHandler",
+          "copyable_doubleTapHandler",
           "viewActivate",
           "viewDeactivate");
       this.model.on("change", this.addAll, this);
@@ -69,6 +71,9 @@
       var text = $(event.target).text();
       window.app.copyToClipboard(text);
       window.app.toastView.show("Copied to clipboard");
+    },
+    copyable_doubleTapHandler: function(event) {
+      this.copyable_longTapHandler(event);
     },
     eye_clickHandler: function(event) {
       var $this = $(event.target);

--- a/tpl/entryView.html
+++ b/tpl/entryView.html
@@ -13,4 +13,4 @@
 	{{ }); }}
 </ul>
 <ul><li class="entriesViewLoading loadingEntries sep">loading...</li></ul>
-<div><p><small>Press and hold (or double click) on a field to copy it to the clipboard</small></p></div>
+<div><p><small>Press and hold{{= ($.os.nodeWebkit) ? ' (or double click)' : '' }} on a field to copy it to the clipboard</small></p></div>

--- a/tpl/entryView.html
+++ b/tpl/entryView.html
@@ -13,4 +13,4 @@
 	{{ }); }}
 </ul>
 <ul><li class="entriesViewLoading loadingEntries sep">loading...</li></ul>
-<div><p><small>Press and hold on a field to copy it to the clipboard</small></p></div>
+<div><p><small>Press and hold (or double click) on a field to copy it to the clipboard</small></p></div>


### PR DESCRIPTION
Global hotkeys and an upgrade to nw.js 

1. Updated nw.js (0.11.5) and the node-webkit grunt plugin (including updating the passed in options)
2. Added a new menu to the Mac version (nw.js no longer creates one by default)
3. Added a global hotkey (`cmd+alt+shift+e` || `ctl+alt+shift+e`) to focus Encryptr as long as it is running

As an added bonus, windows icons are now added during the grunt build stage (to do this on Mac, you need Wine installed)

**This needs testing for regressions due to the updated build tools and nw.js version**