### PR TITLE
Avoid char encoding issues and XAS

### DIFF
--- a/src/views/EntryView.js
+++ b/src/views/EntryView.js
@@ -68,8 +68,11 @@
     copyable_longTapHandler: function(event) {
       event.preventDefault();
       event.stopPropagation();
-      var text = $(event.target).text();
-      window.app.copyToClipboard(text);
+      var type = $(event.target).attr('data-type');
+      var key = _.find(this.model.get("items"), function(item) {
+        return item.key === type;
+      });
+      window.app.copyToClipboard(key.value);
       window.app.toastView.show("Copied to clipboard");
     },
     copyable_doubleTapHandler: function(event) {

--- a/src/views/EntryView.js
+++ b/src/views/EntryView.js
@@ -69,9 +69,11 @@
       event.preventDefault();
       event.stopPropagation();
       var type = $(event.target).attr('data-type');
-      var key = _.find(this.model.get("items"), function(item) {
-        return item.key === type;
-      });
+      //var key = _.find(this.model.get("items"), function(item) {
+        //return item.key === type;
+      //});
+      var key = _.findWhere(this.model.get("items"), { key: type });
+      console.log(key.value);
       window.app.copyToClipboard(key.value);
       window.app.toastView.show("Copied to clipboard");
     },

--- a/src/views/EntryView.js
+++ b/src/views/EntryView.js
@@ -69,11 +69,7 @@
       event.preventDefault();
       event.stopPropagation();
       var type = $(event.target).attr('data-type');
-      //var key = _.find(this.model.get("items"), function(item) {
-        //return item.key === type;
-      //});
       var key = _.findWhere(this.model.get("items"), { key: type });
-      console.log(key.value);
       window.app.copyToClipboard(key.value);
       window.app.toastView.show("Copied to clipboard");
     },

--- a/src/views/MainView.js
+++ b/src/views/MainView.js
@@ -86,7 +86,7 @@
       this.trigger("deleteentry");
     },
     setTitle: function(title) {
-      this.$(".nav .title").html(title);
+      this.$(".nav .title").text(title);
     },
     backButtonDisplay: function(show) {
       if (show) {

--- a/tpl/editListItemView.html
+++ b/tpl/editListItemView.html
@@ -1,5 +1,5 @@
 {{? it.type === 'textarea' }}
 <textarea name="{{= it.id }}" rows="3" placeholder="{{= it.placeholder }}">{{= it.value }}</textarea>
 {{?? }}
-<input type="{{= it.type || 'text' }}" autocorrect="off" autocapitalize="off" name="{{= it.id }}" placeholder="{{= it.placeholder }}" value="{{= it.value }}" />
+<input type="{{= it.type || 'text' }}" autocorrect="off" autocapitalize="off" name="{{= it.id }}" placeholder="{{= it.placeholder }}" value="{{! it.value }}" />
 {{? }}

--- a/tpl/editView.html
+++ b/tpl/editView.html
@@ -1,7 +1,7 @@
 <form>
 	<ul class="flat">
 		<li class="sep">Label *</li>
-    <li class="input"><input type="text" name="label" placeholder="A label to display" value="{{= it.label || '' }}" /></li>
+    <li class="input"><input type="text" name="label" placeholder="A label to display" value="{{! it.label || '' }}" /></li>
 	</ul>
 	<ul class="editable flat"></ul>
 	<div><p><small>* All fields are optional except "label"</small></p></div>

--- a/tpl/entriesListItemView.html
+++ b/tpl/entriesListItemView.html
@@ -1,4 +1,4 @@
 <a>
-  <div>{{= it.label }}</div>
+  <div>{{! it.label }}</div>
   <div><span class='small'>{{= it.type }}</span></div>
 </a>

--- a/tpl/entryView.html
+++ b/tpl/entryView.html
@@ -1,5 +1,5 @@
 <ul>
-	<li><strong>{{= it.label }}</strong></li>
+	<li><strong>{{! it.label }}</strong></li>
 	<!-- <li class="sep">Type</li>
 	<li><em>{{= it.type }}</em></li> -->
 	{{ _.each(it.items, function(item) { }}

--- a/tpl/entryView.html
+++ b/tpl/entryView.html
@@ -5,8 +5,8 @@
 	{{ _.each(it.items, function(item) { }}
     {{? item.value }}<li class="sep">{{= item.key}}</li>
     <li>{{= item.type === 'textarea' ? '<pre>' : ''}}
-      <a class="copyable {{= item.type || item.key.toLowerCase() }}">
-        {{= item.value }}
+      <a data-type="{{= item.key }}" class="copyable {{= item.type || item.key.toLowerCase() }}">
+        {{! item.value }}
       </a>
       {{= item.key === 'Password' ? '<a href="#" class="eye fa fa-eye"></a>' : '' }}
     {{= item.type === 'textarea' ? '</pre>' : ''}}</li>{{? }}


### PR DESCRIPTION
Fixes #137 
Fixes #174 

In order to avoid both XAS and passwords with chars that wouldn't be
copied to the clipboard, instead of taking the text from the actual HTML of the value
field, add the key to the field in a data-attr, then use it to fetch the
value from the model and load that onto the clipboard.

Then (for the XAS), make sure to use the {{! blah }} syntax of DoT to
encode the value before displaying it.